### PR TITLE
fix!: make webhook handler async to properly await callback functions

### DIFF
--- a/__tests__/webhook_client.test.ts
+++ b/__tests__/webhook_client.test.ts
@@ -47,23 +47,23 @@ describe("Webhook Helpers tests", () => {
 		expect(response.body).toBe("CHALLENGE");
 	});
 
-	it("webhook post controller", () => {
+	it("webhook post controller", async () => {
 		const req = {
 			body: {} as any,
 			query: {}
 		};
-		const response = createWebhookPostHandler(events)(req);
+		const response = await createWebhookPostHandler(events)(req);
 		expect(response.status).toBe(200);
 		expect(response.body).toBe("success");
 	});
 
-	it("webhook handler fires the events", () => {
+	it("webhook handler fires the events", async () => {
 		const body = webhookBody;
 		const fields = webhookBodyFields;
 		const contact = body.entry[0].changes[0].value.contacts[0];
 		const metadata = body.entry[0].changes[0].value.metadata;
 
-		webhookHandler(body, events);
+		await webhookHandler(body, events);
 		expect(events.onMessageReceived).toHaveBeenCalledTimes(2);
 		expect(events.onError).toHaveBeenCalledTimes(2);
 		expect(events.onStatusReceived).toHaveBeenCalledTimes(2);

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -486,7 +486,7 @@ export type WebhookEvents = {
 	/**
 	 * Gets fired when the server starts listening
 	 */
-	onStartListening?: () => void;
+	onStartListening?: () => void | Promise<void>;
 	/**
 	 * This event gets fired on any webhooks messages, you'll have to differentiate between the message type
 	 */
@@ -494,7 +494,7 @@ export type WebhookEvents = {
 		payload: WebhookMessage,
 		contact: WebhookContact,
 		metadata?: WebhookMetadata
-	) => void;
+	) => void | Promise<void>;
 	/**
 	 * Gets fired when the received message is type of text
 	 */
@@ -502,14 +502,14 @@ export type WebhookEvents = {
 		textMessage: Pick<WebhookMessage, "type" | "timestamp" | "text" | "from" | "id">,
 		contact: WebhookContact,
 		metadata?: WebhookMetadata
-	) => void;
+	) => void | Promise<void>;
 	/**
 	 * Gets triggered when a message is sent or delivered to a customer
 	 * or the customer reads the delivered message sent by a business that is subscribed to the Webhooks.
 	 */
-	onStatusReceived?: (payload: WebhookStatus, metadata?: WebhookMetadata) => void;
+	onStatusReceived?: (payload: WebhookStatus, metadata?: WebhookMetadata) => void | Promise<void>;
 	/**
 	 * Gets fired whenever there is an err
 	 */
-	onError?: (payload: WebhookError) => void;
+	onError?: (payload: WebhookError) => void | Promise<void>;
 };


### PR DESCRIPTION
The webhook handler was calling async callbacks without awaiting them, which could cause race conditions and unhandled promise rejections. This change makes the webhook handler async and properly awaits all callback functions.

BREAKING CHANGE: webhookHandler is now async and createWebhookPostHandler returns Promise<WebhookResponse>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved webhook event handling to support asynchronous operations, allowing for more flexible and responsive event processing.

* **Refactor**
  * Updated internal processing of webhook events to ensure proper handling of asynchronous event handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->